### PR TITLE
Quick fix of the g_isClassic variable

### DIFF
--- a/NeedToKnow/NeedToKnow.lua
+++ b/NeedToKnow/NeedToKnow.lua
@@ -36,7 +36,7 @@ NeedToKnowLoader = {}
 -- -------------
 -- ADDON MEMBERS
 -- -------------
-local g_isClassic = false;
+local g_isClassic = true;
 if not g_isClassic then
 	local wowversion, wowbuild, wowdate, wowtocversion = GetBuildInfo();
 	g_isClassic = (wowtocversion == 11302);


### PR DESCRIPTION
Fuller fix would be to parse the build number so that subsequent patches don't cause the same issue. 